### PR TITLE
Fix model name for priority_classification.ipynb

### DIFF
--- a/ml/priority_classification.ipynb
+++ b/ml/priority_classification.ipynb
@@ -1390,7 +1390,7 @@
    },
    "outputs": [],
    "source": [
-    "model_name = 'mdl_helpdesk_resolution_time'\n",
+    "model_name = 'mdl_helpdesk_priority'\n",
     "model_version = 'v1'\n",
     "\n",
     "storage_bucket = 'gs://' + google.datalab.Context.default().project_id + '-datalab-workspace/'\n",


### PR DESCRIPTION
priority_classification.ipynb and resolution_time_regression.ipynb are currently trying to upload a model with the same model name, tutorial code at https://cloud.google.com/solutions/smartening-up-support-tickets-with-serverless-ml does not work as written.